### PR TITLE
Refactor `Species` with optional homeworld

### DIFF
--- a/src/SwapiClient/Api.hs
+++ b/src/SwapiClient/Api.hs
@@ -64,7 +64,7 @@ import SwapiClient.Film
 import SwapiClient.Id
 import SwapiClient.Page (Page (Page, NoPage), Index)
 import SwapiClient.Person (Person)
-import SwapiClient.Species (Species)
+import SwapiClient.Species (SpeciesType)
 import SwapiClient.Starship
 import SwapiClient.Url
 import SwapiClient.Url qualified as Url (fromResource)
@@ -437,7 +437,7 @@ eitherSearchVehicles = eitherSearch VehicleResource
 -- ```
 --
 -- If the page provided is `NoPage`, it gives back `Nothing`.
-listSpecies :: Page -> IO (Maybe (Index Species))
+listSpecies :: Page -> IO (Maybe (Index SpeciesType))
 listSpecies = fetchPage SpeciesResource
 
 -- | Fetches a single species associated with the provided `SpeciesId`.
@@ -445,7 +445,7 @@ listSpecies = fetchPage SpeciesResource
 -- `ghci> getSpecies (SpeciesId 6)`
 --
 -- `Just $ Species { ... }`
-getSpecies :: SpeciesId -> IO (Maybe Species)
+getSpecies :: SpeciesId -> IO (Maybe SpeciesType)
 getSpecies (SpeciesId speciesId) = fetchOne SpeciesResource speciesId
 
 -- | Searches for a species' name; results are paginated.
@@ -462,7 +462,7 @@ getSpecies (SpeciesId speciesId) = fetchOne SpeciesResource speciesId
 -- ```
 --
 -- If the page provided is `NoPage`, it gives back `Nothing`.
-searchSpecies :: Text -> Page -> IO (Maybe (Index Species))
+searchSpecies :: Text -> Page -> IO (Maybe (Index SpeciesType))
 searchSpecies = search SpeciesResource
 
 -- | Fetches a list of speciess given a `Page`.
@@ -479,7 +479,7 @@ searchSpecies = search SpeciesResource
 -- ```
 --
 -- If the page provided is `NoPage`, it gives back `Left "This is an empty page"`.
-eitherListSpecies :: Page -> IO (Either String (Index Species))
+eitherListSpecies :: Page -> IO (Either String (Index SpeciesType))
 eitherListSpecies = eitherFetchPage SpeciesResource
 
 -- | Fetches a single species associated with the provided `SpeciesId`.
@@ -487,7 +487,7 @@ eitherListSpecies = eitherFetchPage SpeciesResource
 -- `ghci> eitherGetSpecies (SpeciesId 6)`
 --
 -- `Right $ Species { ... }`
-eitherGetSpecies :: SpeciesId -> IO (Either String Species)
+eitherGetSpecies :: SpeciesId -> IO (Either String SpeciesType)
 eitherGetSpecies (SpeciesId speciesId) =
   eitherFetchOne SpeciesResource speciesId
 
@@ -505,7 +505,7 @@ eitherGetSpecies (SpeciesId speciesId) =
 -- ```
 --
 -- If the page provided is `NoPage`, it gives back `Left "This is an empty page"`.
-eitherSearchSpecies :: Text -> Page -> IO (Either String (Index Species))
+eitherSearchSpecies :: Text -> Page -> IO (Either String (Index SpeciesType))
 eitherSearchSpecies = eitherSearch SpeciesResource
 
 --------------------------------------------------------------------------------

--- a/src/SwapiClient/Species.hs
+++ b/src/SwapiClient/Species.hs
@@ -119,6 +119,8 @@ data Language
   | NoLanguage
   deriving (Eq, Show)
 
+-- | The reason behind why I split `Species` is here:
+-- https://github.com/sekunho/swapi/pull/24
 data SpeciesType
   = HasOrigin Species
   | NoOrigin OriginlessSpecies


### PR DESCRIPTION
The JSON API is a bit strange. This is one of the few times I ran into an actual null value for a field. Normally `none`/`unknown`/`n/a` are used, which I just model with sum types. But this was an actual null! My first instinct was to take advantage of `Maybe`.

Currently `Species` is defined as

```haskell
data Species = Species
  { spName :: SpeciesName
  , spClassification :: Classification
  , spDesignation :: Designation
  , spAverageHeight :: AverageHeight
  , spSkinColors :: [SkinColor]
  , spHairColors :: [HairColor]
  , spEyeColors :: [EyeColor]
  , spAverageLifespan :: AverageLifespan
  , spHomeworld :: Maybe HomeworldId      -- To handle `Null`!
  , spLanguage :: Language
  , spPeople :: [PersonId]
  , spFilms :: [FilmId]
  , spCreatedAt :: UTCTime
  , spEditedAt :: UTCTime
  , spId :: SpeciesId
  }
  deriving (Eq, Show)
```

But this might be annoying to validate is `spHomeworld :: Maybe HomeworldId`. I added the maybe context because not all species have a homeworld.

So to remove the overhead of validation, I replaced it with 2 more types

```haskell
data Species = MkSpecies
  { spName :: SpeciesName
  , spClassification :: Classification
  , spDesignation :: Designation
  , spAverageHeight :: AverageHeight
  , spSkinColors :: [SkinColor]
  , spHairColors :: [HairColor]
  , spEyeColors :: [EyeColor]
  , spAverageLifespan :: AverageLifespan
  , spHomeworld :: HomeworldId
  , spLanguage :: Language
  , spPeople :: [PersonId]
  , spFilms :: [FilmId]
  , spCreatedAt :: UTCTime
  , spEditedAt :: UTCTime
  , spId :: SpeciesId
  }
  deriving (Eq, Show)

data OriginlessSpecies = MkOriginlessSpecies
  { hSpName :: SpeciesName
  , hSpClassification :: Classification
  , hSpDesignation :: Designation
  , hSpAverageHeight :: AverageHeight
  , hSpSkinColors :: [SkinColor]
  , hSpHairColors :: [HairColor]
  , hSpEyeColors :: [EyeColor]
  , hSpAverageLifespan :: AverageLifespan
  , hSpLanguage :: Language
  , hSpPeople :: [PersonId]
  , hSpFilms :: [FilmId]
  , hSpCreatedAt :: UTCTime
  , hSpEditedAt :: UTCTime
  , hSpId :: SpeciesId
  }
  deriving (Eq, Show)
```

Then I created a sum type that relates them in some way

```haskell
data SpeciesType
  = HasOrigin Species
  | NoOrigin OriginlessSpecies
  deriving (Eq, Show)
```

I also had to fix the `FromJSON` instances. The behavior I wanted was when `aeson` runs into a `Null` value in `homeworld`, I want to use the `OriginlessSpecies` instance, otherwise it's `Species`.

```haskell
instance FromJSON (Species :: Type) where
  parseJSON :: Value -> Parser Species
  parseJSON =
    Aeson.withObject "Species" $
      \val ->
        MkSpecies
          <$> val .: "name"
          <*> val .: "classification"
          <*> val .: "designation"
          <*> val .: "average_height"
          <*> val .: "skin_colors"
          <*> val .: "hair_colors"
          <*> val .: "eye_colors"
          <*> val .: "average_lifespan"
          <*> val .: "homeworld"
          <*> val .: "language"
          <*> val .: "people"
          <*> val .: "films"
          <*> val .: "created"
          <*> val .: "edited"
          <*> val .: "url"

instance FromJSON (OriginlessSpecies :: Type) where
  parseJSON :: Value -> Parser OriginlessSpecies
  parseJSON =
    Aeson.withObject "OriginlessSpecies" $
      \val ->
        MkOriginlessSpecies
          <$> val .: "name"
          <*> val .: "classification"
          <*> val .: "designation"
          <*> val .: "average_height"
          <*> val .: "skin_colors"
          <*> val .: "hair_colors"
          <*> val .: "eye_colors"
          <*> val .: "average_lifespan"
          <*> val .: "language"
          <*> val .: "people"
          <*> val .: "films"
          <*> val .: "created"
          <*> val .: "edited"
          <*> val .: "url"

instance FromJSON (SpeciesType :: Type) where
  parseJSON :: Value -> Parser SpeciesType
  parseJSON =
    Aeson.withObject "SpeciesType" $
      \val ->
        case Keymap.lookup "homeworld" val of
          Nothing -> fail "Species is supposed to contain a homeworld field."
          Just val' -> case val' of
            String _ -> HasOrigin <$> parseJSON @Species (Object val)
            Null -> NoOrigin <$> parseJSON @OriginlessSpecies (Object val)
            _ ->
              fail "Species' homeworld field is supposed to be null or a string."

instance FromJSON (Index SpeciesType :: Type) where
  parseJSON :: Value -> Parser (Index SpeciesType)
  parseJSON =
    Aeson.withObject "Index Species" $
      \val ->
        Index
          <$> val .: "count"
          <*> val .: "next"
          <*> val .: "previous"
          <*> val .: "results"
```

It was a bit confusing at first especially with using `parseJSON` within `parseJSON`. I just followed the types and found my way to the solution. There might be better ways around this that I'm not seeing right now, but hey, it works!

The breakage isn't that bad. I just had to replace all instances of `Species` and `Index Species` with the `SpeciesType` counterpart. 

`getSpecies (SpeciesId 2)` (no homeworld) results in this output

```haskell
Just $ 
  NoOrigin $ 
    MkOriginlessSpecies 
      { hSpName = SpeciesName "Droid"
      , hSpClassification = ArtificialClass
      , hSpDesignation = SentientDesignation
      , hSpAverageHeight = HeightNotApplicable
      , hSpSkinColors = [SkinColorNotApplicable]
      , hSpHairColors = [NoHairColor]
      , hSpEyeColors = [EyeColorNotApplicable]
      , hSpAverageLifespan = Indefinite
      , hSpLanguage = NoLanguage
      , hSpPeople = [PersonId 2,PersonId 3,PersonId 8,PersonId 23]
      , hSpFilms = [FilmId 1,FilmId 2,FilmId 3,FilmId 4,FilmId 5,FilmId 6]
      , hSpCreatedAt = 2014-12-10 15:16:16.259 UTC
      , hSpEditedAt = 2014-12-20 21:36:42.139 UTC
      , hSpId = SpeciesId 2
      }
```

While `getSpecies (SpeciesId 1)` (has homeworld) results in this output

I could probably refine this further by creating types for each class but I think that might be too much. There's a possibility, however.